### PR TITLE
Restore Android ELF runpath

### DIFF
--- a/codex-rs/.cargo/config.toml
+++ b/codex-rs/.cargo/config.toml
@@ -13,7 +13,7 @@ rustflags = ["-C", "link-arg=-Wl,--stack,8388608"]
 [target.aarch64-linux-android]
 ar = "llvm-ar"
 linker = "aarch64-linux-android-clang"
-rustflags = ["-C", "link-arg=-lc++_shared"]
+rustflags = ["-C", "link-arg=-lc++_shared", "-C", "link-arg=-Wl,-rpath,$ORIGIN"]
 
 [env]
 AR_aarch64_linux_android = "llvm-ar"

--- a/patches/README.md
+++ b/patches/README.md
@@ -60,6 +60,11 @@ These are the practical fork deltas most relevant for end users.
 - Goal: fix failures like:
   - `CANNOT LINK EXECUTABLE ... libc++_shared.so not found`
   when tools invoke binaries directly without Node wrapper env or when `LD_LIBRARY_PATH` is sanitised.
+- Verification:
+  - source wiring is checked in `verify-patches.sh`
+  - when a built binary pair is present, `verify-patches.sh` also runs `readelf -d`
+    and requires `RUNPATH` or `RPATH` to contain `$ORIGIN` on both `codex` and
+    `codex-exec`
 
 ### Patch #11 - Disable voice/realtime audio in published Termux builds (0.111.0)
 - Files:
@@ -117,7 +122,9 @@ Run from repo root:
 bash verify-patches.sh
 ```
 
-The script verifies critical runtime patches and checks that patch files declared in `MODULE.bazel` exist.
+The script verifies critical runtime patches, checks that patch files declared in
+`MODULE.bazel` exist, and performs Patch #10 runtime ELF verification when a
+built binary pair is available in standard target/package locations.
 
 ## 5) Diff workflow against upstream
 

--- a/patches/README.md
+++ b/patches/README.md
@@ -56,9 +56,10 @@ These are the practical fork deltas most relevant for end users.
   - `codex`/`codex-exec` are launcher scripts.
   - real ELF binaries moved to `codex.bin` / `codex-exec.bin`.
   - launcher exports safe `LD_LIBRARY_PATH` before `exec`.
+  - Android binaries keep `RUNPATH=$ORIGIN` so direct ELF invocation can still resolve bundled `libc++_shared.so`.
 - Goal: fix failures like:
   - `CANNOT LINK EXECUTABLE ... libc++_shared.so not found`
-  when tools invoke binaries directly without Node wrapper env.
+  when tools invoke binaries directly without Node wrapper env or when `LD_LIBRARY_PATH` is sanitised.
 
 ### Patch #11 - Disable voice/realtime audio in published Termux builds (0.111.0)
 - Files:

--- a/verify-patches.sh
+++ b/verify-patches.sh
@@ -10,6 +10,56 @@ echo ""
 pass() { echo "✅ PRESENT"; }
 fail() { echo "❌ MISSING!"; exit 1; }
 
+binary_has_origin_runpath() {
+  local binary="$1"
+
+  readelf -d "$binary" 2>/dev/null \
+    | grep -E '(RUNPATH|RPATH)' \
+    | grep -F '$ORIGIN' >/dev/null
+}
+
+is_elf_binary() {
+  local binary="$1"
+
+  readelf -h "$binary" >/dev/null 2>&1
+}
+
+detect_runtime_pair() {
+  local search_roots=(
+    "npm-package/bin"
+    "codex-rs/target/debug"
+    "codex-rs/target/release"
+    "codex-rs/target/ci-test"
+  )
+  local root
+
+  if [ -n "${CARGO_TARGET_DIR:-}" ]; then
+    search_roots+=(
+      "$CARGO_TARGET_DIR/debug"
+      "$CARGO_TARGET_DIR/release"
+      "$CARGO_TARGET_DIR/ci-test"
+    )
+  fi
+
+  for root in "${search_roots[@]}"; do
+    if [ -x "$root/codex.bin" ] && [ -x "$root/codex-exec.bin" ] \
+      && is_elf_binary "$root/codex.bin" \
+      && is_elf_binary "$root/codex-exec.bin"; then
+      printf '%s\n%s\n' "$root/codex.bin" "$root/codex-exec.bin"
+      return 0
+    fi
+
+    if [ -x "$root/codex" ] && [ -x "$root/codex-exec" ] \
+      && is_elf_binary "$root/codex" \
+      && is_elf_binary "$root/codex-exec"; then
+      printf '%s\n%s\n' "$root/codex" "$root/codex-exec"
+      return 0
+    fi
+  done
+
+  return 1
+}
+
 # Patch #1
 printf "Patch #1 (Browser Login): "
 if grep -q "target_os.*android" codex-rs/login/src/server.rs \
@@ -69,10 +119,22 @@ if grep -q 'exec "\$SCRIPT_DIR/codex.bin"' npm-package/bin/codex \
   && grep -q '"bin/codex.bin"' npm-package/package.json \
   && grep -q '"bin/codex-exec.bin"' npm-package/package.json \
   && grep -q 'link-arg=-Wl,-rpath,$ORIGIN' codex-rs/.cargo/config.toml; then
-  if [ -x npm-package/bin/codex.bin ] && [ -x npm-package/bin/codex-exec.bin ]; then
-    pass
+  if runtime_pair=$(detect_runtime_pair); then
+    runtime_codex=$(printf '%s\n' "$runtime_pair" | sed -n '1p')
+    runtime_codex_exec=$(printf '%s\n' "$runtime_pair" | sed -n '2p')
+
+    if binary_has_origin_runpath "$runtime_codex" \
+      && binary_has_origin_runpath "$runtime_codex_exec"; then
+      echo "✅ PRESENT (runtime proof ok: $(basename "$runtime_codex"), $(basename "$runtime_codex_exec"))"
+    else
+      echo "❌ MISSING!"
+      echo "  Runtime proof failed for:"
+      echo "  - $runtime_codex"
+      echo "  - $runtime_codex_exec"
+      exit 1
+    fi
   else
-    echo "✅ PRESENT (launchers + package wiring ok; binaries supplied at packaging/release time)"
+    echo "✅ PRESENT (source wiring ok; runtime proof skipped because no binary pair was found)"
   fi
 else
   fail

--- a/verify-patches.sh
+++ b/verify-patches.sh
@@ -67,7 +67,8 @@ if grep -q 'exec "\$SCRIPT_DIR/codex.bin"' npm-package/bin/codex \
   && grep -q 'LD_LIBRARY_PATH' npm-package/bin/codex \
   && grep -q 'LD_LIBRARY_PATH' npm-package/bin/codex-exec \
   && grep -q '"bin/codex.bin"' npm-package/package.json \
-  && grep -q '"bin/codex-exec.bin"' npm-package/package.json; then
+  && grep -q '"bin/codex-exec.bin"' npm-package/package.json \
+  && grep -q 'link-arg=-Wl,-rpath,$ORIGIN' codex-rs/.cargo/config.toml; then
   if [ -x npm-package/bin/codex.bin ] && [ -x npm-package/bin/codex-exec.bin ]; then
     pass
   else


### PR DESCRIPTION
## Summary

Restore an Android runpath on the native Codex ELF so `codex.bin` can resolve its bundled `libc++_shared.so` even when it is launched directly without the Node wrapper environment.

Bug report: https://github.com/GFernie/codex-termux/issues/1

## Problem

On Termux, the latest package can fail when `apply_patch` or another direct native-binary launch path bypasses the wrapper-provided `LD_LIBRARY_PATH`.

Observed interactive `apply_patch` failure:

```text
• Added thread_apply_patch_probe.txt (+1 -0)
    1 +probe

✘ Failed to apply patch
  └ CANNOT LINK EXECUTABLE "/data/data/com.termux/files/usr/lib/node_modules/@mmmbuto/codex-cli-termux/bin/codex.bin": library "libc++_shared.so" not found: needed by main executable
```

The same failure is also reproducible by launching the packaged ELF directly in a stripped environment.

## Change

This PR keeps the runtime fix minimal:
- add `-Wl,-rpath,$ORIGIN` next to the existing Android `-lc++_shared` linker flag in `codex-rs/.cargo/config.toml`
- strengthen `verify-patches.sh` so Patch #10 performs runtime ELF verification when a built binary pair is available
- document that stronger verification in the patch inventory

With that change, the rebuilt Android binary carries a runpath containing `$ORIGIN`, so the loader can find the sibling shared runtime without depending on wrapper-set environment variables.

## Validation

- `bash verify-patches.sh`
- `readelf -d` confirms the older known-good packaged binaries expose `RUNPATH [$ORIGIN]` on both `codex.bin` and `codex-exec.bin`
- `readelf -d` confirms the newer broken packaged binaries do not expose that runpath, which is the regression pattern this check is meant to catch

`verify-patches.sh` now behaves in two modes:
- source-only checkout: verifies the launcher/package wiring and reports that runtime proof was skipped because no ELF pair was found
- built/package checkout: additionally requires `RUNPATH` or `RPATH` containing `$ORIGIN` on both binaries

## Scope

This PR is intentionally limited to the Android linker regression. A separate Termux issue around persistent approval rule storage (`lock() not supported`) is not part of this change (https://github.com/GFernie/codex-termux/issues/3).
