### PR TITLE
Fix Android SDK license step under pipefail

### DIFF
--- a/.github/workflows/termux-npm-build-publish.yml
+++ b/.github/workflows/termux-npm-build-publish.yml
@@ -88,7 +88,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          yes | sdkmanager --licenses >/dev/null
+          yes | sdkmanager --licenses >/dev/null || true
           sdkmanager "ndk;26.3.11579264"
           ndk_root="${ANDROID_SDK_ROOT}/ndk/26.3.11579264"
           echo "ANDROID_NDK_HOME=${ndk_root}" >> "$GITHUB_ENV"


### PR DESCRIPTION
Prevents the Android NDK setup step from failing when `sdkmanager --licenses` closes the `yes` pipe under `set -o pipefail`.