### PR TITLE
Use pinned Rust 1.93.0 for Android CI target

### DIFF
--- a/.github/workflows/termux-npm-build-publish.yml
+++ b/.github/workflows/termux-npm-build-publish.yml
@@ -74,8 +74,9 @@ jobs:
         with:
           ref: ${{ github.event.inputs.source_ref }}
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: 1.93.0
           targets: aarch64-linux-android
 
       - uses: actions/setup-node@v6


### PR DESCRIPTION
Align the Android workflow with `codex-rs/rust-toolchain.toml` so the `aarch64-linux-android` target is installed for the pinned 1.93.0 toolchain instead of `stable`.