### PR TITLE
Document maintainer release and publish flow

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -77,6 +77,8 @@ cp "$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib/aarc
 - Termux patch verification lives in `verify-patches.sh`.
 - The maintainer GitHub Actions workflow is `.github/workflows/termux-npm-build-publish.yml`.
 - Fork-owned Android `rusty_v8` assets are described in `third_party/v8/android-artifacts.toml`.
+- The canonical publish path is GitHub Actions on `main`, not a local Termux build on `asusrp3`.
+- Recommended order: run once with `create_release=true`, validate artifacts, then run again with `publish_npm=true`.
 
 If the Android `rusty_v8` pair for the resolved crate version does not exist
 yet, bootstrap a source checkout with:

--- a/README.md
+++ b/README.md
@@ -102,6 +102,12 @@ This keeps the packaged binaries free of Android audio linker dependencies while
 - npm latest: [`@mmmbuto/codex-cli-termux`](https://www.npmjs.com/package/@mmmbuto/codex-cli-termux)
 - npm LTS: [`@mmmbuto/codex-cli-lts`](https://www.npmjs.com/package/@mmmbuto/codex-cli-lts)
 
+Maintainer release flow:
+
+- trigger `.github/workflows/termux-npm-build-publish.yml` on `main`
+- run once with `create_release=true` to publish GitHub release assets
+- run again with `publish_npm=true` when the release artifacts are validated
+
 ## Documentation
 
 - [Changelog](./CHANGELOG.md)

--- a/npm-package/README.md
+++ b/npm-package/README.md
@@ -23,6 +23,7 @@ codex login
 - Packaged launchers preserve bundled `libc++_shared.so` visibility
 - Android ELFs are hardened with `RUNPATH=$ORIGIN`
 - Fork-owned Android `rusty_v8` prebuilds are used for maintainer cross-builds
+- Maintainer publish path is the repository GitHub Actions workflow on `main`
 
 See the main repository for release notes and patch inventory:
 


### PR DESCRIPTION
Keep the fork README and linked docs aligned with the current GitHub Actions release flow, with minimal wording changes only.