### PR TITLE
Checkout repository in release-assets job

### DIFF
--- a/.github/workflows/termux-npm-build-publish.yml
+++ b/.github/workflows/termux-npm-build-publish.yml
@@ -208,6 +208,10 @@ jobs:
     permissions:
       contents: write
     steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.inputs.source_ref }}
+
       - uses: actions/download-artifact@v4
         with:
           name: android-arm64-release-assets


### PR DESCRIPTION
The release job uses `gh release create/upload`, which expects a checked-out git repository. Add `actions/checkout` to `release-assets` so GitHub release publication works after successful Android build and npm pack.